### PR TITLE
HTTPURLResponse added to serializationError

### DIFF
--- a/Source/NetworkError.swift
+++ b/Source/NetworkError.swift
@@ -36,7 +36,7 @@ public enum NetworkError: Error {
     /// Error on the server (HTTP Error 500...511)
     case serverError(response: HTTPURLResponse?, data: Data?)
     /// Parsing the body into expected type failed.
-    case serializationError(error: Error, data: Data?)
+    case serializationError(error: Error, response: HTTPURLResponse?, data: Data?)
     /// Complete request failed.
     case requestError(error: Error)
     
@@ -79,21 +79,26 @@ extension NetworkError: CustomDebugStringConvertible {
         case .cancelled:
             return "Request cancelled"
         case .unauthorized(let response, let data):
-            return "Authorization error: \(response), response: ".appendingContentsOf(data: data)
+            return "Authorization error, response headers: \(response), response body: ".appendingContentsOf(data: data)
         case .clientError(let response, let data):
-            if let response = response {
-                return "Client error: \((response)), response: ".appendingContentsOf(data: data)
+            if let response {
+                return "Client error, response headers: \(response), response body: ".appendingContentsOf(data: data)
+            } else {
+                return "Client error, response headers: nil, response body: ".appendingContentsOf(data: data)
             }
-            return "Client error, response: ".appendingContentsOf(data: data)
-        case .serializationError(let description, let data):
-            return "Serialization error: \(description), response: ".appendingContentsOf(data: data)
+        case .serializationError(let error, let response, let data):
+            if let response {
+                return "Serialization error: \(error), response headers: \(response), response body: ".appendingContentsOf(data: data)
+            } else {
+                return "Serialization error: \(error), response headers: nil, response body: ".appendingContentsOf(data: data)
+            }
         case .requestError(let error):
             return "Request error: \(error)"
         case .serverError(let response, let data):
-            if let response = response {
-                return "Server error: \(String(describing: response)), response: ".appendingContentsOf(data: data)
+            if let response {
+                return "Server error, response headers: \(response), response body: ".appendingContentsOf(data: data)
             } else {
-                return "Server error: nil, response: ".appendingContentsOf(data: data)
+                return "Server error, response headers: nil, response body: ".appendingContentsOf(data: data)
             }
         }
     }

--- a/Source/NetworkResponseProcessor.swift
+++ b/Source/NetworkResponseProcessor.swift
@@ -48,13 +48,13 @@ final class NetworkResponseProcessor {
         if let responseError = NetworkError(response: response, data: data) {
             throw responseError
         }
-        guard let data = data else {
+        guard let data, let response else {
             throw NetworkError.serverError(response: response, data: nil)
         }
         do {
-            return try resource.parse(data)
+            return try resource.parse(response, data)
         } catch let error {
-            throw NetworkError.serializationError(error: error, data: data)
+            throw NetworkError.serializationError(error: error, response: response, data: data)
         }
     }
     

--- a/Source/Resource+Decodable.swift
+++ b/Source/Resource+Decodable.swift
@@ -32,7 +32,7 @@ extension Resource where Model: Decodable {
     ///   - request: The request to get the remote data payload
     ///   - decoder: a decoder which can decode the payload into the model type
     public init(request: URLRequest, decoder: JSONDecoder) {
-        self.init(request: request, parse: { try decoder.decode(Model.self, from: $0) })
+        self.init(request: request, parse: { try decoder.decode(Model.self, from: $1) })
     }
 }
 
@@ -46,6 +46,6 @@ extension ResourceWithError where Model: Decodable {
     ///   - decoder: a decoder which can decode the payload into the model type
     ///   - mapError: a closure which maps to Error
     public init(request: URLRequest, decoder: JSONDecoder, mapError: @escaping (_ networkError: NetworkError) -> E) {
-        self.init(request: request, parse: { try decoder.decode(Model.self, from: $0) }, mapError: mapError)
+        self.init(request: request, parse: { try decoder.decode(Model.self, from: $1) }, mapError: mapError)
     }
 }

--- a/Source/Resource+Inspect.swift
+++ b/Source/Resource+Inspect.swift
@@ -36,10 +36,10 @@ extension Resource {
      - parameter inspector: closure which gets passed the data
      - returns: a new resource which gets instepcted before parsing
      */
-    public func inspectData(_ inspector: @escaping (Data) -> Void) -> Resource<Model> {
-        return Resource(request: request, parse: { data in
-            inspector(data)
-            return try self.parse(data)
+    public func inspectData(_ inspector: @escaping (HTTPURLResponse, Data) -> Void) -> Resource<Model> {
+        return Resource(request: request, parse: { response, data in
+            inspector(response, data)
+            return try self.parse(response, data)
         })
     }
 

--- a/Source/Resource+Map.swift
+++ b/Source/Resource+Map.swift
@@ -28,8 +28,8 @@ extension Resource {
     /// - Parameter transform: transforms the original result of the resource
     /// - Returns: the transformed resource
     public func map<T>(transform: @escaping (Model) throws -> T) -> Resource<T> {
-        return Resource<T>(request: request, parse: { data in
-            return try transform(try self.parse(data))
+        return Resource<T>(request: request, parse: { response, data in
+            return try transform(try self.parse(response, data))
         })
     }
 }
@@ -45,8 +45,8 @@ extension ResourceWithError {
     public func map<T>(transform: @escaping (Model) throws -> T) -> ResourceWithError<T, E> {
         return ResourceWithError<T, E>(
             request: request,
-            parse: { data in
-                return try transform(try self.parse(data))
+            parse: { response, data in
+                return try transform(try self.parse(response, data))
             },
             mapError: mapError
         )

--- a/Source/Resource+Void.swift
+++ b/Source/Resource+Void.swift
@@ -14,7 +14,7 @@ public extension Resource where Model == Void {
     /// - Parameters:
     ///   - request: The request to get the remote data payload
     init(request: URLRequest) {
-        self.init(request: request, parse: { _ in })
+        self.init(request: request, parse: { _,_  in })
     }
 }
 
@@ -26,6 +26,6 @@ extension ResourceWithError where Model == Void {
     ///   - request: The request to get the remote data payload
     ///   - mapError: a closure which maps to Error
     public init(request: URLRequest, mapError: @escaping (_ networkError: NetworkError) -> E) {
-        self.init(request: request, parse: { _ in }, mapError: mapError)
+        self.init(request: request, parse: { _,_   in }, mapError: mapError)
     }
 }

--- a/Source/Resource.swift
+++ b/Source/Resource.swift
@@ -40,14 +40,14 @@ public struct Resource<Model> {
     public let request: URLRequest
     
     /// Parses data into given model.
-    public let parse: (_ data: Data) throws -> Model
-    
+    public let parse: (_ response: HTTPURLResponse, _ data: Data) throws -> Model
+
     /// Creates a type safe resource, which can be used to fetch it with `NetworkService`
     ///
     /// - Parameters:
     ///   - request: The request to get the remote data payload
     ///   - parse: Parses data fetched with the request into given Model
-    public init(request: URLRequest, parse: @escaping (Data) throws -> Model) {
+    public init(request: URLRequest, parse: @escaping (HTTPURLResponse, Data) throws -> Model) {
         self.request = request
         self.parse = parse
     }

--- a/Source/ResourceWithError.swift
+++ b/Source/ResourceWithError.swift
@@ -42,7 +42,7 @@ public struct ResourceWithError<Model, E: Error> {
     public let request: URLRequest
     
     /// Parses data into given model.
-    public let parse: (_ data: Data) throws -> Model
+    public let parse: (_ response: HTTPURLResponse, _ data: Data) throws -> Model
     public let mapError: (_ networkError: NetworkError) -> E
     
     /// Creates a type safe resource, which can be used to fetch it with NetworkService
@@ -51,7 +51,7 @@ public struct ResourceWithError<Model, E: Error> {
     /// - request: The request to get the remote data payload
     /// - parse: Parses data fetched with the request into given Model
     
-    public init(request: URLRequest, parse: @escaping (Data) throws -> Model, mapError: @escaping (_ networkError: NetworkError) -> E) {
+    public init(request: URLRequest, parse: @escaping (HTTPURLResponse, Data) throws -> Model, mapError: @escaping (_ networkError: NetworkError) -> E) {
         self.request = request
         self.parse = parse
         self.mapError = mapError

--- a/Tests/DecodableResoureTest.swift
+++ b/Tests/DecodableResoureTest.swift
@@ -33,8 +33,8 @@ class DecodableResoureTest: XCTestCase {
     
     func testResource_withValidData() {
         //When
-        let fetchedTrain = try? resource.parse(Train.validJSONData)
-        
+        let fetchedTrain = try? resource.parse(HTTPURLResponse.defaultMock, Train.validJSONData)
+
         //Then
         XCTAssertEqual(fetchedTrain?.name, "ICE")
     }
@@ -42,8 +42,8 @@ class DecodableResoureTest: XCTestCase {
     func testResource_withMAppedResult() {
         //When
         let nameResource = resource.map { $0.name }
-        let fetchedTrainName = try? nameResource.parse(Train.validJSONData)
-        
+        let fetchedTrainName = try? nameResource.parse(HTTPURLResponse.defaultMock, Train.validJSONData)
+
         //Then
         XCTAssertEqual(fetchedTrainName, "ICE")
     }
@@ -51,7 +51,7 @@ class DecodableResoureTest: XCTestCase {
     func testResource_WithInvalidData() throws {
         //When
         do {
-            _ = try resource.parse(Train.invalidJSONData)
+            _ = try resource.parse(HTTPURLResponse.defaultMock, Train.invalidJSONData)
             XCTFail("Expected method to throws")
         } catch { }
     }

--- a/Tests/ModifyRequestNetworkService.swift
+++ b/Tests/ModifyRequestNetworkService.swift
@@ -41,7 +41,7 @@ class ModifyRequestNetworkServiceTest: XCTestCase {
             } ]
         let networkService: NetworkService = ModifyRequestNetworkService(networkService: networkServiceMock, requestModifications: modification)
         let request = URLRequest(path: "/trains", baseURL: .defaultMock)
-        let resource = Resource<Int>(request: request, parse: { _ in return 1 })
+        let resource = Resource<Int>(request: request, parse: { _,_  in return 1 })
         
         //When
         networkService.request(resource, onCompletion: { _ in }, onError: { _ in })

--- a/Tests/NetworkErrorTest.swift
+++ b/Tests/NetworkErrorTest.swift
@@ -138,8 +138,8 @@ class NetworkErrorTest: XCTestCase {
         let debugDescription = error.debugDescription
         
         //Then
-        XCTAssert(debugDescription.hasPrefix("Authorization error: <NSHTTPURLResponse: "))
-        XCTAssert(debugDescription.hasSuffix("response: dataString"))
+        XCTAssert(debugDescription.hasPrefix("Authorization error, "))
+        XCTAssert(debugDescription.hasSuffix("response body: dataString"))
     }
     
     func testUnknownError_clientError_description() {
@@ -152,21 +152,22 @@ class NetworkErrorTest: XCTestCase {
         let debugDescription = error.debugDescription
         
         //Then
-        XCTAssert(debugDescription.hasPrefix("Client error: <NSHTTPURLResponse: "))
-        XCTAssert(debugDescription.hasSuffix("response: dataString"))
+        XCTAssert(debugDescription.hasPrefix("Client error, "))
+        XCTAssert(debugDescription.hasSuffix("response body: dataString"))
     }
     
     func testUnknownError_serializationError_description() {
         //Given
         let nserror = NSError(domain: "TestError", code: 0, userInfo: nil)
         let data = "dataString".data(using: .utf8)
-        let error: NetworkError = .serializationError(error: nserror, data: data)
+        let error: NetworkError = .serializationError(error: nserror, response: HTTPURLResponse.defaultMock, data: data)
         
         //When
         let debugDescription = error.debugDescription
         
         //Then
-        XCTAssertEqual(debugDescription, "Serialization error: Error Domain=TestError Code=0 \"(null)\", response: dataString")
+        XCTAssert(debugDescription.hasPrefix("Serialization error: Error Domain=TestError Code=0 \"(null)\""))
+        XCTAssert(debugDescription.hasSuffix("{ Status Code: 200, Headers {\n} }, response body: dataString"))
     }
     
     func testUnknownError_requestError_description() {

--- a/Tests/NetworkResponseProcessorTest.swift
+++ b/Tests/NetworkResponseProcessorTest.swift
@@ -35,7 +35,7 @@ class NetworkResponseProcessingTests: XCTestCase {
     
     func testCancelError() {
         // Given
-        let resource = Resource(request: URLRequest.defaultMock, parse: { _ in return 0 })
+        let resource = Resource(request: URLRequest.defaultMock, parse: { _, _ in return 0 })
         let cancelledError = URLError(_nsError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
         
         // When
@@ -61,7 +61,7 @@ class NetworkResponseProcessingTests: XCTestCase {
     
     func testParseThrowsUnknownError() {
         // Given
-        let resource = Resource(request: URLRequest.defaultMock, parse: { _  -> Int in
+        let resource = Resource(request: URLRequest.defaultMock, parse: { _, _  -> Int in
             throw NetworkError.unknownError })
         let data: Data! = "Data".data(using: .utf8)
         
@@ -71,7 +71,7 @@ class NetworkResponseProcessingTests: XCTestCase {
         } catch let error as NetworkError {
             // Then
             switch error {
-            case .serializationError(let error, let recievedData): // Excpected
+            case .serializationError(let error, _, let receivedData): // Expected
                 switch error as? NetworkError {
                 case .unknownError?:
                     XCTAssert(true)
@@ -79,7 +79,7 @@ class NetworkResponseProcessingTests: XCTestCase {
                     XCTFail("Expects unknownError")
                 }
                 
-                XCTAssertEqual(recievedData, data)
+                XCTAssertEqual(receivedData, data)
             default:
                 XCTFail("Expected cancelled error (got \(error)")
             }
@@ -90,11 +90,11 @@ class NetworkResponseProcessingTests: XCTestCase {
     
     func testParseSucessFullWithNilResponse() {
         //Given
-        let resource = Resource(request: URLRequest.defaultMock, parse: { _ in return 0 })
+        let resource = Resource(request: URLRequest.defaultMock, parse: { _,_  in return 0 })
         
         //When
         do {
-            _ = try processor.process(response: nil, resource: resource, data: Data(), error: nil)
+            _ = try processor.process(response: HTTPURLResponse.defaultMock, resource: resource, data: Data(), error: nil)
         } catch let error as NetworkError {
             // Then
             switch error {

--- a/Tests/NetworkServiceMockTest.swift
+++ b/Tests/NetworkServiceMockTest.swift
@@ -28,7 +28,7 @@ class NetworkServiceMockTest: XCTestCase {
     
     var networkServiceMock: NetworkServiceMock!
     
-    let resource = Resource<Int>(request: URLRequest(path: "/trains", baseURL: .defaultMock), parse: { _ in return 1 })
+    let resource = Resource<Int>(request: URLRequest(path: "/trains", baseURL: .defaultMock), parse: { _,_  in return 1 })
     
     override func setUp() {
         networkServiceMock = NetworkServiceMock()

--- a/Tests/NetworkServiceTest.swift
+++ b/Tests/NetworkServiceTest.swift
@@ -90,14 +90,14 @@ class NetworkServiceTest: XCTestCase {
     
     func testRequest_withFailingSerialization() {
         //Given
-        networkAccess.changeMock(data: Train.JSONDataWithInvalidKey, response: nil, error: nil)
+        networkAccess.changeMock(data: Train.JSONDataWithInvalidKey, response: HTTPURLResponse.defaultMock, error: nil)
         let expection = expectation(description: "testRequest_withFailingSerialization")
         
         //When
         networkService.request(resource, onCompletion: { _ in
             XCTFail("Should not call success block")
         }, onError: { (error: NetworkError) in
-                if case .serializationError(_, _) = error {
+                if case .serializationError(_, _, _) = error {
                     expection.fulfill()
                 } else {
                     XCTFail("Expects serializationError")

--- a/Tests/ResourceInspectTest.swift
+++ b/Tests/ResourceInspectTest.swift
@@ -29,17 +29,17 @@ final class ResourceInspectTest: XCTestCase {
         let data = Data()
         var capuredParsingData: Data?
         var capturedInspectedData: Data?
-        let resource = Resource<Int>(request: URLRequest.defaultMock, parse: { data in
+        let resource = Resource<Int>(request: URLRequest.defaultMock, parse: { response, data in
             capuredParsingData = data
             return 1
         })
         
         //When
-        let inspectedResource = resource.inspectData({ data in
+        let inspectedResource = resource.inspectData({ response, data in
             capturedInspectedData = data
         })
-        let result = try? inspectedResource.parse(data)
-        
+        let result = try? inspectedResource.parse(HTTPURLResponse.defaultMock, data)
+
         //Then
         XCTAssertNotNil(result)
         XCTAssertEqual(capuredParsingData, capturedInspectedData)

--- a/Tests/ResourceTest.swift
+++ b/Tests/ResourceTest.swift
@@ -31,11 +31,11 @@ class ResourceTest: XCTestCase {
         //Given
         let validData: Data! = "ICE".data(using: .utf8)
 
-        let resource = Resource<String?>(request: URLRequest.defaultMock, parse: { String(data: $0, encoding: .utf8) })
-        
+        let resource = Resource<String?>(request: URLRequest.defaultMock, parse: { String(data: $1, encoding: .utf8) })
+
         //When
-        let name = try? resource.parse(validData)
-        
+        let name = try? resource.parse(HTTPURLResponse.defaultMock, validData)
+
         //Then
         XCTAssertEqual(name ?? nil, "ICE")
     }

--- a/Tests/ResourceWithErrorTest.swift
+++ b/Tests/ResourceWithErrorTest.swift
@@ -33,12 +33,12 @@ class ResourceWithErrorTest: XCTestCase {
 
         let resource = ResourceWithError<String?, NetworkError>(
             request: URLRequest.defaultMock,
-            parse: { String(data: $0, encoding: .utf8) },
+            parse: { String(data: $1, encoding: .utf8) },
             mapError: { $0 }
         )
         
         //When
-        let name = try? resource.parse(validData)
+        let name = try? resource.parse(HTTPURLResponse.defaultMock, validData)
         
         //Then
         XCTAssertEqual(name ?? nil, "ICE")

--- a/Tests/RetryNetworkserviceTest.swift
+++ b/Tests/RetryNetworkserviceTest.swift
@@ -28,7 +28,7 @@ class RetryNetworkserviceTest: XCTestCase {
     var networkServiceMock: NetworkServiceMock!
     var resource: Resource<Int> {
         let request = URLRequest(path: "/train", baseURL: .defaultMock)
-        return Resource(request: request, parse: { _ in return 1})
+        return Resource(request: request, parse: { _,_  in return 1})
     }
     
     override func setUp() {


### PR DESCRIPTION
Fixes issues: 

A serialization error would now also carry the HTTPURLResponse info.

New feature:

#### Make sure to check all boxes before merging

- [x] Method/Class documentation / not applicable
- [x] README.md documentation / not applicable
- [x] Unit tests for new features/regressions
